### PR TITLE
Add support for an array of strings in config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4927,9 +4927,9 @@
       "dev": true
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "inquirer": {

--- a/src/documenters/DocumenterConfig.ts
+++ b/src/documenters/DocumenterConfig.ts
@@ -28,7 +28,7 @@ export class DocumenterConfig {
     /**
      * Specifies how packages must start to be included, so non matching package names are excluded.
      */
-    public onlyPackagesStartingWith?: string;
+    public onlyPackagesStartingWith?: string | string[];
 
     /**
      * The JSON Schema for API Extractor config file (api-extractor.schema.json).

--- a/src/documenters/IConfigFile.ts
+++ b/src/documenters/IConfigFile.ts
@@ -84,7 +84,7 @@ export interface IConfigFile {
     /**
      * Specifies how packages must start to be included, so non matching package names are excluded.
      */
-    onlyPackagesStartingWith?: string;
+    onlyPackagesStartingWith?: string | string[];
 
     /**
      * This enables an experimental feature that will be officially released with the next major version

--- a/src/documenters/MarkdownDocumenter.ts
+++ b/src/documenters/MarkdownDocumenter.ts
@@ -1382,8 +1382,18 @@ export class MarkdownDocumenter {
     }
 
     private _isAllowedPackage(pkg: ApiPackage): boolean {
-        if (this._documenterConfig && this._documenterConfig!.onlyPackagesStartingWith) {
-            return pkg.name.startsWith(this._documenterConfig!.onlyPackagesStartingWith)
+        const config = this._documenterConfig;
+        if (config && config.onlyPackagesStartingWith) {
+            if (typeof config.onlyPackagesStartingWith === "string") {
+                return pkg.name.startsWith(config.onlyPackagesStartingWith);
+            } else {
+                for (const prefix of config.onlyPackagesStartingWith) {
+                    if (pkg.name.startsWith(prefix)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
         }
         return true;
     }

--- a/src/documenters/MarkdownDocumenter.ts
+++ b/src/documenters/MarkdownDocumenter.ts
@@ -1387,12 +1387,7 @@ export class MarkdownDocumenter {
             if (typeof config.onlyPackagesStartingWith === "string") {
                 return pkg.name.startsWith(config.onlyPackagesStartingWith);
             } else {
-                for (const prefix of config.onlyPackagesStartingWith) {
-                    if (pkg.name.startsWith(prefix)) {
-                        return true;
-                    }
-                }
-                return false;
+                return config.onlyPackagesStartingWith.some((prefix) => pkg.name.startsWith(prefix));
             }
         }
         return true;

--- a/src/documenters/MarkdownDocumenter.ts
+++ b/src/documenters/MarkdownDocumenter.ts
@@ -1145,7 +1145,7 @@ export class MarkdownDocumenter {
         let apiMembers: ReadonlyArray<ApiItem> = item.members;
         const mdEmitter = this._markdownEmitter;
 
-        var extractSummary = function (docComment: DocComment): string {
+        var extractSummary = (docComment: DocComment): string => {
             const tmpStrBuilder: StringBuilder = new StringBuilder();
             const summary: DocSection = docComment!.summarySection;
             mdEmitter.emit(tmpStrBuilder, summary, {

--- a/src/schemas/api-documenter.schema.json
+++ b/src/schemas/api-documenter.schema.json
@@ -32,7 +32,7 @@
     },
     "onlyPackagesStartingWith": {
       "description": "Specifies how packages must start to be included, so non matching package names are excluded.",
-      "type": "array",
+      "type": ["string", "array"],
       "default": ""
     },
     "newDocfxNamespaces": {

--- a/src/schemas/api-documenter.schema.json
+++ b/src/schemas/api-documenter.schema.json
@@ -32,7 +32,7 @@
     },
     "onlyPackagesStartingWith": {
       "description": "Specifies how packages must start to be included, so non matching package names are excluded.",
-      "type": "string",
+      "type": "array",
       "default": ""
     },
     "newDocfxNamespaces": {


### PR DESCRIPTION
This PR enables configs with multiple values for `onlyPackagesStartingWith`.